### PR TITLE
Added Name attribute to subreport nodes

### DIFF
--- a/Converters/PblToRepxConverter.cs
+++ b/Converters/PblToRepxConverter.cs
@@ -111,7 +111,7 @@ internal class PblToRepxConverter(string inputDir, string outputDir)
         var dataWindowAttributes = structure[0]._attributes;
         var dataSourceRef = _ref++;
 
-        WriteStartObject($"<ReportSource Ref=\"{_ref++}\" ControlType=\"ReportMigration.XtraReports.{attributes["dataobject"]}, ReportMigration, Version=1.0.0.0, Culture=neutral\" VerticalContentSplitting=\"Smart\" Margins=\"{X(dataWindowAttributes["print.margin.left"])}, {X(dataWindowAttributes["print.margin.right"])}, {Y(dataWindowAttributes["print.margin.top"])}, {Y(dataWindowAttributes["print.margin.bottom"])}\" PaperKind=\"Custom\" PageWidth=\"{parser.ReportWidth}\" PageHeight=\"{parser.ReportHeight}\" Version=\"24.1\" DataMember=\"Query\" DataSource=\"#Ref-{dataSourceRef}\">");
+        WriteStartObject($"<ReportSource Ref=\"{_ref++}\" Name=\"{attributes["dataobject"]}\" ControlType=\"ReportMigration.XtraReports.{attributes["dataobject"]}, ReportMigration, Version=1.0.0.0, Culture=neutral\" VerticalContentSplitting=\"Smart\" Margins=\"{X(dataWindowAttributes["print.margin.left"])}, {X(dataWindowAttributes["print.margin.right"])}, {Y(dataWindowAttributes["print.margin.top"])}, {Y(dataWindowAttributes["print.margin.bottom"])}\" PaperKind=\"Custom\" PageWidth=\"{parser.ReportWidth}\" PageHeight=\"{parser.ReportHeight}\" Version=\"24.1\" DataMember=\"Query\" DataSource=\"#Ref-{dataSourceRef}\">");
 
         var tableContainer = (TableModel)structure.Where(x => x.GetType() == typeof(TableModel)).ToList()[0];
         var argList = PBFormattingHelper.GetParameters(tableContainer._attributes["arguments"]);


### PR DESCRIPTION
The subreport's name wasn't passed on the subreport's XML node. It could in theory be extracted from the ControlType, but C# DevExpress libraries erase this information when loading the report at runtime.